### PR TITLE
Terraform module for provisioning Amazon Redshift clusteradded module for redshift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,40 @@
+# Local .terraform directories
+**/.terraform/*
+
+.terraform.lock.hcl
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+
+# Ignore environment files containing secrets for local execution of terraform
+.env
+# Ignore .vscode folder and all the consisting files
+.vscode/
+
+# Ignore .idea folder and all the consisting files
+.idea/.terraform/

--- a/README.md
+++ b/README.md
@@ -1,44 +1,77 @@
-# terraform-aws-template
+# terraform-aws-redshift
 
-[![Lint Status](https://github.com/tothenew/terraform-aws-template/workflows/Lint/badge.svg)](https://github.com/tothenew/terraform-aws-template/actions)
-[![LICENSE](https://img.shields.io/github/license/tothenew/terraform-aws-template)](https://github.com/tothenew/terraform-aws-template/blob/master/LICENSE)
+[![Lint Status](https://github.com/tothenew/terraform-aws-redshift/workflows/Lint/badge.svg)](https://github.com/tothenew/terraform-aws-redshift/actions)
+[![LICENSE](https://img.shields.io/github/license/tothenew/terraform-aws-redshift)](https://github.com/tothenew/terraform-aws-redshift/blob/master/LICENSE)
 
-This is a template to use for baseline. The default actions will provide updates for section bitween Requirements and Outputs.
+This module provisions and configures an **Amazon Redshift** cluster within a specified VPC. It includes security group creation and subnet configuration to meet infrastructure requirements.
 
-The following content needed to be created and managed:
- - Introduction
-     - Explaination of module 
-     - Intended users
- - Resource created and managed by this module
- - Example Usages
+The following resources will be created:
+
+* AWS Redshift Cluster
+* Redshift Subnet Group
+* Security Group for Redshift access
+
+## Usage
+
+```hcl
+module "redshift_cluster" {
+  source                 = "./module/redshift"
+  cluster_identifier     = "example-cluster"
+  database_name          = "test_db"
+  master_username        = "test_user"
+  master_password        = "abcdefGhijklm1"
+  subnet_ids             = ["subnet-0123456789", "subnet-0987654321"]
+}
+```
 
 <!-- BEGIN_TF_DOCS -->
+
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| Name      | Version  |
+| --------- | -------- |
+| terraform | >= 1.3.0 |
 
 ## Providers
 
-No providers.
+| Name | Version |
+| ---- | ------- |
+| aws  | n/a     |
 
 ## Modules
 
-No modules.
+| Name            | Source            | Version |
+| --------------- | ----------------- | ------- |
+| redshift_cluster | ./module/redshift | n/a     |
 
 ## Resources
 
-No resources.
+| Name                               | Type     |
+| ---------------------------------- | -------- |
+| aws_redshift_cluster               | resource |
+| aws_redshift_subnet_group          | resource |
+| aws_security_group.redshift_sg     | resource |
 
 ## Inputs
 
-No inputs.
+| Name                    | Description                                               | Type          | Default                                       | Required |
+| ----------------------- | --------------------------------------------------------- | ------------- | --------------------------------------------- | :------: |
+| name                    | Prefix for resource naming                                | string        | `"non-prod-generic"`                          |   no     |
+| cluster_identifier      | Identifier for the Redshift cluster                       | string        | `"example"`                                   |   no     |
+| node_type               | Node type for the cluster                                 | string        | `"DC2.large"`                                 |   no     |
+| number_of_nodes         | Number of compute nodes                                   | number        | `1`                                           |   no     |
+| subnet_ids              | List of subnet IDs                                        | list(string)  | `["subnet-0123456789", "subnet-0987654321"]`  |   no     |
+| vpc_id                  | VPC ID for Redshift                                       | string        | `"vpc-0123gj4567890"`                         |   no     |
+| cidr_blocks             | CIDR blocks allowed to access the Redshift cluster        | list(string)  | `["10.0.0.0/16"]`                             |   no     |
+
 
 ## Outputs
 
-No outputs.
-<!-- END_TF_DOCS -->
+| Name                  | Description                          |
+| --------------------- | ------------------------------------ |
+| redshift_cluster_id   | ID of the Redshift cluster           |
+| redshift_endpoint     | Endpoint address of the Redshift DB  |
+| redshift_arn          | ARN of the Redshift cluster          |
 
 ## Authors
 
@@ -46,4 +79,4 @@ Module managed by [TO THE NEW Pvt. Ltd.](https://github.com/tothenew)
 
 ## License
 
-Apache 2 Licensed. See [LICENSE](https://github.com/tothenew/terraform-aws-template/blob/main/LICENSE) for full details.
+Apache 2 Licensed. See [LICENSE](https://github.com/tothenew/terraform-aws-redshift/blob/main/LICENSE) for full details.

--- a/_locals.tf
+++ b/_locals.tf
@@ -1,0 +1,5 @@
+locals {
+  project_name_prefix = var.name == "" ? terraform.workspace : var.name
+  service_name_prefix = var.name == "" ? terraform.workspace : var.name
+  common_tags         = length(var.common_tags) == 0 ? var.default_tags : merge(var.default_tags, var.common_tags)
+}

--- a/_variables.tf
+++ b/_variables.tf
@@ -1,0 +1,121 @@
+variable "name" {
+  type        = string
+  description = "A string value to describe prefix of all the resources"
+  default     = "non-prod-generic"
+}
+
+variable "cluster_identifier" {
+  description = "Identifier for the Redshift cluster"
+  type        = string
+  default     = "example"
+}
+
+variable "allow_version_upgrade" {
+  description = "If true, major version upgrades can be applied during maintenance windows"
+  type        = bool
+  default     = true
+}
+
+variable "node_type" {
+  description = "The node type to be provisioned for the cluster"
+  type        = string
+  default     = "DC2.large"
+}
+
+variable "number_of_nodes" {
+  description = "Number of compute nodes in the Redshift cluster"
+  type        = number
+  default     = 1
+}
+
+variable "database_name" {
+  description = "Name of the first database to be created when the cluster is created"
+  type        = string
+  default     = "test_db"
+}
+
+variable "master_username" {
+  description = "Username for the master DB user"
+  type        = string
+  default     = "test_user"
+}
+
+variable "master_password" {
+  description = "Password for the master DB user"
+  type        = string
+  default     = "abcdefGhijklm1"
+  sensitive   = true
+}
+
+variable "encrypted" {
+  description = "If true, the data in the cluster is encrypted at rest"
+  type        = bool
+  default     = true
+}
+
+variable "kms_key_id" {
+  description = "KMS key used to encrypt data in the cluster"
+  type        = string
+  default     = "arn:aws:kms:us-east-1:001861987316:key/mrk-85156372d29c4714bcf185c8bb82bbdc"
+}
+
+variable "enhanced_vpc_routing" {
+  description = "If true, enhanced VPC routing is enabled"
+  type        = bool
+  default     = true
+}
+
+variable "subnet_ids" {
+  description = "List of subnet IDs for the Redshift cluster"
+  type        = list(string)
+  default     = ["subnet-0123456789", "subnet-0987654321"]
+}
+
+variable "sg_name" {
+  description = "Name of the subnet"
+  type        = string
+  default     = "redshift-sg"
+}
+
+variable "vpc_id" {
+  description = "The VPC ID where redshift will be deployed"
+  type        = string
+  default     = "vpc-0123gj4567890"
+}
+
+variable "cidr_blocks" {
+  type        = list(string)
+  description = "A list of CIDR block ID's to allow access"
+  default     = ["10.0.0.0/16"]
+}
+
+variable "from_port" {
+  description = "security groups from port"
+  type        = number
+  default     = 5439
+}
+
+variable "to_port" {
+  description = "security groups to port"
+  type        = number
+  default     = 5439
+}
+
+variable "common_tags" {
+  type        = map(string)
+  description = "A map to add common tags to all the resources"
+  default = {
+    "Project"     = "Internal"
+    "Environment" = "Dev"
+    "ManagedBy"   = "Terraform"
+  }
+}
+
+variable "default_tags" {
+  type        = map(string)
+  description = "A map to add common tags to all the resources"
+  default = {
+    "Scope" : "DMS"
+    "CreatedBy" : "Terraform"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,19 @@
+module "redshift_cluster" {
+  source                 = "./module/redshift"
+  cluster_identifier     = var.cluster_identifier
+  allow_version_upgrade  = var.allow_version_upgrade
+  node_type              = var.node_type
+  number_of_nodes        = var.number_of_nodes
+  database_name          = var.database_name
+  master_username        = var.master_username
+  master_password        = var.master_password
+  encrypted              = var.encrypted
+  kms_key_id             = var.kms_key_id
+  enhanced_vpc_routing   = var.enhanced_vpc_routing
+  vpc_security_group_ids = [aws_security_group.redshift_cluster_sg.id]
+  subnet_ids             = var.subnet_ids
+  tags = merge(var.common_tags,
+    {
+      Name = "${local.service_name_prefix}-redshift"
+  })
+}

--- a/module/redshift/main.tf
+++ b/module/redshift/main.tf
@@ -1,0 +1,23 @@
+resource "aws_redshift_cluster" "example" {
+  cluster_identifier    = var.cluster_identifier
+  allow_version_upgrade = var.allow_version_upgrade
+  node_type             = var.node_type
+  number_of_nodes       = var.number_of_nodes
+  database_name         = var.database_name
+  master_username       = var.master_username
+  master_password       = var.master_password
+  encrypted             = var.encrypted
+  kms_key_id            = var.kms_key_id
+  enhanced_vpc_routing  = var.enhanced_vpc_routing
+  vpc_security_group_ids = var.vpc_security_group_ids
+  cluster_subnet_group_name = aws_redshift_subnet_group.this.name
+  skip_final_snapshot   = var.skip_final_snapshot
+  tags                  = var.tags
+
+}
+
+resource "aws_redshift_subnet_group" "this" {
+  name       = "${var.cluster_identifier}-subnet-group"
+  subnet_ids = var.subnet_ids
+  tags       = var.tags
+}

--- a/module/redshift/output.tf
+++ b/module/redshift/output.tf
@@ -1,0 +1,9 @@
+output "cluster_id" {
+  description = "The ID of the Redshift cluster"
+  value       = aws_redshift_cluster.example.id
+}
+
+output "endpoint" {
+  description = "The endpoint of the Redshift cluster"
+  value       = aws_redshift_cluster.example.endpoint
+}

--- a/module/redshift/variable.tf
+++ b/module/redshift/variable.tf
@@ -1,0 +1,69 @@
+variable "cluster_identifier" {
+  description = "The name of the cluster"
+  type        = string
+}
+
+variable "allow_version_upgrade" {
+  description = "The name of the cluster"
+  type        = string
+}
+
+variable "enhanced_vpc_routing" {
+  description = "The name of the cluster"
+  type        = string
+}
+
+variable "node_type" {
+  description = "Node type for the Redshift cluster"
+  type        = string
+}
+
+variable "number_of_nodes" {
+  description = "Number of nodes for the Redshift cluster"
+  type        = number
+}
+
+variable "database_name" {
+  description = "The name of the database"
+  type        = string
+}
+
+variable "master_username" {
+  description = "The master username for the cluster"
+  type        = string
+}
+
+variable "master_password" {
+  description = "The master password for the cluster"
+  type        = string
+}
+
+variable "encrypted" {
+  description = "Whether the cluster should be encrypted"
+  type        = bool
+}
+
+variable "kms_key_id" {
+  description = "KMS Key ARN for encryption"
+  type        = string
+}
+
+variable "vpc_security_group_ids" {
+  description = "List of VPC security group IDs"
+  type        = list(string)
+}
+
+variable "subnet_ids" {
+  description = "List of subnet IDs for the cluster"
+  type        = list(string)
+}
+
+variable "skip_final_snapshot" {
+  type    = bool
+  default = true
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "A map of tags to add to all resources"
+}

--- a/security-group.tf
+++ b/security-group.tf
@@ -1,0 +1,16 @@
+resource "aws_security_group" "redshift_cluster_sg" {
+  name        = var.sg_name
+  description = "redshift_cluster security group"
+  vpc_id      = var.vpc_id
+  tags = merge(local.common_tags, tomap({
+    "Name" : local.project_name_prefix
+    })
+  )
+
+  ingress {
+    from_port   = var.from_port
+    to_port     = var.to_port
+    protocol    = "tcp"
+    cidr_blocks = var.cidr_blocks
+  }
+}


### PR DESCRIPTION
This PR introduces a new Terraform module named terraform-aws-redshift to provision and manage Amazon Redshift clusters. The module includes:
    Redshift cluster creation with configurable parameters
    Redshift subnet group setup
    Security group with customizable CIDR rules
    Encryption support via KMS
    Enhanced VPC routing option
    Example usage and complete documentation in README.md